### PR TITLE
Add GetParticipantsHandler and refactor participant handling

### DIFF
--- a/api/handlers/participant.go
+++ b/api/handlers/participant.go
@@ -33,6 +33,25 @@ func GetMeHandler(w http.ResponseWriter, r *http.Request) {
 	utils.JSONResponse(w, me, http.StatusOK)
 }
 
+func GetParticipantsHandler(w http.ResponseWriter, r *http.Request) {
+	roomID := r.PathValue("room_id")
+	if roomID == "" {
+		http.Error(w, "room id not found", http.StatusBadRequest)
+		return
+	}
+
+	allParticipants, participantsInCall, err := participant.GetParticipants(roomID)
+	if err != nil {
+		http.Error(w, "failed to get participants", http.StatusBadRequest)
+		return
+	}
+
+	utils.JSONResponse(w, map[string]any{
+		"participants":       allParticipants,
+		"participantsInCall": participantsInCall,
+	}, http.StatusOK)
+}
+
 func SetSessionHandler(w http.ResponseWriter, r *http.Request) {
 	roomID := r.PathValue("room_id")
 	if roomID == "" {

--- a/api/handlers/room.go
+++ b/api/handlers/room.go
@@ -128,22 +128,3 @@ func GetRoomInfoHandler(w http.ResponseWriter, r *http.Request) {
 
 	utils.JSONResponse(w, roomInfo.CreatedAt, http.StatusOK)
 }
-
-func GetParticipantsHandler(w http.ResponseWriter, r *http.Request) {
-	roomID := r.PathValue("room_id")
-	if roomID == "" {
-		http.Error(w, "room id not found", http.StatusBadRequest)
-		return
-	}
-
-	allParticipants, participantsInCall, err := participant.GetParticipants(roomID)
-	if err != nil {
-		http.Error(w, "failed to get participants", http.StatusBadRequest)
-		return
-	}
-
-	utils.JSONResponse(w, map[string]any{
-		"participants":       allParticipants,
-		"participantsInCall": participantsInCall,
-	}, http.StatusOK)
-}

--- a/internal/participant/lobby.go
+++ b/internal/participant/lobby.go
@@ -8,11 +8,6 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-// Broadcast participant's id, as username might not be set yet in lobby
-type Guest struct {
-	ID string `json:"id"`
-}
-
 // Subscribes to the participants-in-lobby broadcast channel
 func ParticipantsSubscription(roomID string, conn *websocket.Conn) {
 	done := make(chan struct{})
@@ -32,7 +27,7 @@ func ParticipantsSubscription(roomID string, conn *websocket.Conn) {
 	}()
 
 	go func() {
-		subscriber := rdb.Client().Subscribe(rdb.Context(), "room:"+roomID+":participants_lobby")
+		subscriber := rdb.Client().Subscribe(rdb.Context(), "room:"+roomID+":participants")
 		defer subscriber.Close()
 
 		for {
@@ -48,7 +43,7 @@ func ParticipantsSubscription(roomID string, conn *websocket.Conn) {
 					return
 				}
 
-				var participantsData []Guest
+				var participantsData []*Participant
 				err = json.Unmarshal([]byte(msg.Payload), &participantsData)
 				if err != nil {
 					fmt.Println("error unmarshalling message", err)
@@ -72,14 +67,14 @@ func ParticipantsSubscription(roomID string, conn *websocket.Conn) {
 	<-done
 }
 
-// Broadcasts the  participants-in-lobby update to all connected clients in the room
-func BroadcastParticipantsUpdate(roomID string, participants []Guest) (bool, error) {
+// Broadcasts the participants-in-lobby update to all connected clients in the room
+func BroadcastParticipantsUpdate(roomID string, participants []*Participant) (bool, error) {
 	payloadJSON, err := json.Marshal(participants)
 	if err != nil {
 		return false, err
 	}
 
-	if err := rdb.Client().Publish(rdb.Context(), "room:"+roomID+":participants_lobby", payloadJSON).Err(); err != nil {
+	if err := rdb.Client().Publish(rdb.Context(), "room:"+roomID+":participants", payloadJSON).Err(); err != nil {
 		return false, err
 	}
 

--- a/internal/room/actions.go
+++ b/internal/room/actions.go
@@ -61,7 +61,7 @@ func JoinRoom(roomID string) (*participant.Participant, error) {
 
 	// Broadcast participants-in-lobby update (only ID, as username might not be set yet in lobby)
 	if p.SessionID == "" {
-		participant.BroadcastParticipantsUpdate(roomID, []participant.Guest{
+		participant.BroadcastParticipantsUpdate(roomID, []*participant.Participant{
 			{
 				ID: p.ID,
 			},


### PR DESCRIPTION
Introduced GetParticipantsHandler to retrieve participants for a specific room. Refactored participant data structure from Guest to Participant and updated related functions for consistency. Removed deprecated GetParticipantsHandler from room.go.